### PR TITLE
optimized "native support" check

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -9,24 +9,23 @@
 		
 **/
 (function($) {
+	var native_support = ('placeholder' in document.createElement('input'));
 	$.fn.placeholder = function(command) {
-		if(command) {
-			switch(command) {
-				case 'clear':
-					this.each(function() {
-						var el = $(this)
-						if(el.data('isEmpty') || el.val() == el.attr('placeholder')) {
-							el.val('');
-						}
-					});
-				break;
-			}
-			return this;
-		}
-		
-		var native_support = ('placeholder' in document.createElement('input'));
-		
 		if(!native_support) {
+			if(command) {
+				switch(command) {
+					case 'clear':
+						this.each(function() {
+							var el = $(this)
+							if(el.data('isEmpty') || el.val() == el.attr('placeholder')) {
+								el.val('');
+							}
+						});
+					break;
+				}
+				return this;
+			}
+
 			this.each(function() {
 				if(!$(this).data('gotPlaceholder')) {
 					$(this).focus(function() {


### PR DESCRIPTION
I relocated the native support check so it is only run once instead of every time new input elements are initialized with the placeholder plugin.
